### PR TITLE
Fix CORS middleware ordering in CatalogService

### DIFF
--- a/CatalogService/src/CatalogService.Web/Program.cs
+++ b/CatalogService/src/CatalogService.Web/Program.cs
@@ -158,15 +158,15 @@ else
   app.UseHsts();
 }
 
-app.UseCors(builder => builder
-     .AllowAnyOrigin()
-     .AllowAnyMethod()
-     .AllowAnyHeader());
 if (!app.Environment.IsDevelopment())
 {
   app.UseHttpsRedirection();
 }
 app.UseRouting();
+app.UseCors(builder => builder
+     .AllowAnyOrigin()
+     .AllowAnyMethod()
+     .AllowAnyHeader());
 app.UseStaticFiles();
 app.UseResponseCaching();
 


### PR DESCRIPTION
Move app.UseCors() to after app.UseRouting() so that endpoint-level [EnableCors] attributes (e.g. on CategoriesController.CreateCategory) are resolved correctly, resolving the 500 error on POST /api/v1/category.