### PR TITLE
Fix deleted item still showing in admin items list

### DIFF
--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -191,8 +191,8 @@ export default function AdminPage() {
     if (!window.confirm('Delete this item?')) return;
     try {
       await adminApi.deleteItem(instance, selectedCatId, itemId);
+      setItems(prev => prev.filter(item => item.id !== itemId));
       setItemMsg({ type: 'success', text: 'Item deleted.' });
-      loadItems(selectedCatId);
     } catch (err) {
       setItemMsg({ type: 'error', text: err.message });
     }


### PR DESCRIPTION
Replace server re-fetch after delete with a local state filter, so the item is immediately removed from the UI without a stale round-trip.