### PR TITLE
Add local file storage as dev replacement for Azure Blob Storage

### DIFF
--- a/CatalogService/src/CatalogService.Infrastructure/Services/BlobStorageServiceLocal.cs
+++ b/CatalogService/src/CatalogService.Infrastructure/Services/BlobStorageServiceLocal.cs
@@ -1,0 +1,31 @@
+using CatalogService.Core.Interfaces;
+using Microsoft.Extensions.Configuration;
+
+namespace CatalogService.Infrastructure.Services;
+
+public class BlobStorageServiceLocal : IBlobStorageService
+{
+  private readonly string _folderPath;
+  private readonly string _baseUrl;
+
+  public BlobStorageServiceLocal(IConfiguration config)
+  {
+    _folderPath = config["LocalStorage:FolderPath"]
+        ?? throw new InvalidOperationException("LocalStorage:FolderPath is not configured.");
+    _baseUrl = config["LocalStorage:BaseUrl"]?.TrimEnd('/')
+        ?? throw new InvalidOperationException("LocalStorage:BaseUrl is not configured.");
+
+    Directory.CreateDirectory(_folderPath);
+  }
+
+  public async Task<string> UploadAsync(Stream stream, string fileName, string contentType, CancellationToken ct = default)
+  {
+    var blobName = $"{Guid.NewGuid()}-{Path.GetFileName(fileName)}";
+    var filePath = Path.Combine(_folderPath, blobName);
+
+    await using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+    await stream.CopyToAsync(fileStream, ct);
+
+    return $"{_baseUrl}/{blobName}";
+  }
+}

--- a/CatalogService/src/CatalogService.Web/Program.cs
+++ b/CatalogService/src/CatalogService.Web/Program.cs
@@ -143,6 +143,15 @@ builder.Services.AddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
 builder.Services.AddScoped<ICategoryService, CategoryService>();
 builder.Services.AddScoped<IItemService, ItemService>();
 
+if (builder.Environment.IsDevelopment())
+{
+  builder.Services.AddScoped<IBlobStorageService, BlobStorageServiceLocal>();
+}
+else
+{
+  builder.Services.AddScoped<IBlobStorageService, BlobStorageService>();
+}
+
 //builder.Logging.AddAzureWebAppDiagnostics(); add this if deploying to Azure
 builder.Services.ConfigureSwagger();
 var app = builder.Build();
@@ -168,6 +177,19 @@ app.UseCors(builder => builder
      .AllowAnyMethod()
      .AllowAnyHeader());
 app.UseStaticFiles();
+
+if (app.Environment.IsDevelopment())
+{
+  var uploadsPath = Path.Combine(app.Environment.ContentRootPath,
+      app.Configuration["LocalStorage:FolderPath"] ?? "wwwroot/uploads");
+  Directory.CreateDirectory(uploadsPath);
+  app.UseStaticFiles(new StaticFileOptions
+  {
+    FileProvider = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(uploadsPath),
+    RequestPath = "/uploads"
+  });
+}
+
 app.UseResponseCaching();
 
 app.UseAuthentication();

--- a/CatalogService/src/CatalogService.Web/appsettings.json
+++ b/CatalogService/src/CatalogService.Web/appsettings.json
@@ -39,5 +39,9 @@
   },
   "BlobStorage": {
     "ContainerName": "mentoringecommerceimages"
+  },
+  "LocalStorage": {
+    "FolderPath": "wwwroot/uploads",
+    "BaseUrl": "http://localhost:5001/uploads"
   }
 }


### PR DESCRIPTION
Introduces BlobStorageServiceLocal which saves uploaded images to a configurable local folder and returns a URL served via static files, avoiding the need for Azure credentials in local development.