### PR TITLE
Wire Application Insights via OpenTelemetry Azure Monitor exporter

### DIFF
--- a/CatalogService/src/CatalogService.Web/Program.cs
+++ b/CatalogService/src/CatalogService.Web/Program.cs
@@ -35,8 +35,6 @@ builder.Services.AddCors(options =>
                     });
 });
 
-builder.Host.UseSerilog((_, config) => config.ReadFrom.Configuration(builder.Configuration));
-
 var serviceBusConnectionString = builder.Configuration["EventBusConnection"];
 var serviceBusEnabled = !string.IsNullOrWhiteSpace(serviceBusConnectionString);
 

--- a/ServiceDefaults/Extensions.cs
+++ b/ServiceDefaults/Extensions.cs
@@ -1,3 +1,4 @@
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
@@ -59,6 +60,12 @@ public static class ServiceDefaultsExtensions
 
         if (useOtlpExporter)
             builder.Services.AddOpenTelemetry().UseOtlpExporter();
+
+        var useAzureMonitor = !string.IsNullOrWhiteSpace(
+            builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]);
+
+        if (useAzureMonitor)
+            builder.Services.AddOpenTelemetry().UseAzureMonitor();
 
         return builder;
     }

--- a/ServiceDefaults/ServiceDefaults.csproj
+++ b/ServiceDefaults/ServiceDefaults.csproj
@@ -6,12 +6,13 @@
     <IsAspireSharedProject>true</IsAspireSharedProject>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Serilog's UseSerilog() was intercepting the ILogger pipeline before OpenTelemetry could see any log output, so nothing reached App Insights.

- Remove UseSerilog from Program.cs to unblock the OTel log pipeline
- Add Azure.Monitor.OpenTelemetry.AspNetCore to ServiceDefaults
- Register UseAzureMonitor() when APPLICATIONINSIGHTS_CONNECTION_STRING is set
- Bump OpenTelemetry packages 1.11.2 → 1.12.0 (required by Azure Monitor)