### PR TITLE
Fix invalid JSON in appsettings.json causing startup crash

### DIFF
--- a/CatalogService/src/CatalogService.Web/appsettings.json
+++ b/CatalogService/src/CatalogService.Web/appsettings.json
@@ -11,32 +11,6 @@
   },
   "SubscriptionClientName": "catalogservice",
   "EventBusConnection": "Endpoint=sb://catalog.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=qxMKk/AsYiAIEgCIlnrF6TIXIyC4ZwiM3906lceN4pw=",
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information"
-    },
-    "WriteTo": [
-      {
-        "Name": "Console"
-      },
-      {
-        "Name": "File",
-        "Args": {
-          "path": "log.txt",
-          "rollingInterval": "Day"
-        }
-      }
-      //Uncomment this section if you'd like to push your logs to Azure Application Insights
-      //Full list of Serilog Sinks can be found here: https://github.com/serilog/serilog/wiki/Provided-Sinks
-      //{
-      //  "Name": "ApplicationInsights",
-      //  "Args": {
-      //    "instrumentationKey": "", //Fill in with your ApplicationInsights InstrumentationKey
-      //    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-      //  }
-      //}
-    ]
-  },
   "BlobStorage": {
     "AccountName": "mentoringecommerceimages",
     "ContainerName": "catalog-images"


### PR DESCRIPTION
// comments are not valid JSON — the parser threw InvalidDataException on startup. Removed the commented-out Serilog Application Insights sink block along with the now-unused Serilog node (UseSerilog was removed in the previous commit).